### PR TITLE
fix: CSS rendering in production 

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,7 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Word Finder{% endblock %}</title>
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+    <!-- Base styles -->
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css', v='1.0') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css', v='1.0') }}">
     {% block extra_css %}{% endblock %}
 </head>
 <body>
@@ -16,7 +18,7 @@
         {% block content %}{% endblock %}
     </main>
 
-    <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/main.js', v='1.0') }}"></script>
     {% block extra_js %}{% endblock %}
 </body>
 </html> 

--- a/package.json
+++ b/package.json
@@ -8,8 +8,11 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "tailwindcss -i ./app/static/css/tailwind.css -o ./app/static/css/main.css --minify",
-    "watch": "tailwindcss -i ./app/static/css/tailwind.css -o ./app/static/css/main.css --watch"
+    "build": "NODE_ENV=production tailwindcss -i ./app/static/css/tailwind.css -o ./app/static/css/main.css --minify",
+    "watch": "tailwindcss -i ./app/static/css/tailwind.css -o ./app/static/css/main.css --watch",
+    "postinstall": "npm run build",
+    "clean": "rm -rf app/static/css/main.css",
+    "rebuild": "npm run clean && npm run build"
   },
   "repository": {
     "type": "git",
@@ -25,6 +28,7 @@
   "devDependencies": {
     "autoprefixer": "^10.4.19",
     "postcss": "^8.4.38",
-    "tailwindcss": "^3.4.1"
+    "tailwindcss": "^3.4.1",
+    "@tailwindcss/forms": "^0.5.7"
   }
 }

--- a/render.yaml
+++ b/render.yaml
@@ -5,9 +5,27 @@ services:
     region: oregon
     plan: free
     buildCommand: |
+      # Install Python dependencies
       pip install -r requirements.txt
+      
+      # Install and build frontend assets
       npm install
+      echo "Building CSS..."
       npm run build
+      
+      # Verify CSS build
+      echo "Verifying CSS build..."
+      if [ ! -f "app/static/css/main.css" ]; then
+        echo "Error: main.css was not generated"
+        exit 1
+      fi
+      
+      # List CSS files for verification
+      echo "CSS files in app/static/css/:"
+      ls -la app/static/css/
+      
+      # Ensure proper permissions
+      chmod -R 755 app/static/css/
     startCommand: |
       export PYTHONPATH=$PYTHONPATH:$(pwd)
       gunicorn wsgi:app --workers 2 --bind 0.0.0.0:$PORT --timeout 120
@@ -23,3 +41,7 @@ services:
         generateValue: true
       - key: FLASK_APP
         value: wsgi.py
+      - key: NODE_ENV
+        value: production
+      - key: TAILWIND_MODE
+        value: build


### PR DESCRIPTION
Add robust CSS build process in render.yaml 
Update package.json with production build scripts
Add version query params for cache busting
Ensure proper CSS loading order in base template