### PR TITLE
Handle Unicode letters in position constraints

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -35,8 +35,9 @@ def parse_position_constraints(position_input, language='tr'):
     # Split by spaces to handle multiple position constraints
     parts = position_input.strip().split()
     for part in parts:
-        # Match pattern like "1ABC" or "4XYZ"
-        match = re.match(r'(\d+)([A-Za-z]+)', part)
+        # Match pattern like "1ABC" or "4XYZ" using Unicode-aware letters
+        # Previous pattern used [A-Za-z]+ which failed for non-ASCII letters
+        match = re.match(r'(\d+)([^\W\d_]+)', part, re.UNICODE)
         if match:
             position = int(match.group(1))
             if language == 'tr':

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,0 +1,10 @@
+import pytest
+from app.utils import parse_position_constraints
+
+def test_parse_position_constraints_turkish_letters():
+    result = parse_position_constraints('1Ç 3Ğ', language='tr')
+    assert result == {0: {'ç'}, 2: {'ğ'}}
+
+def test_parse_position_constraints_unicode_letters_other_language():
+    result = parse_position_constraints('2É', language='fr')
+    assert result == {1: {'é'}}


### PR DESCRIPTION
## Summary
- fix position constraint parser to recognize non-ASCII letters
- add tests for Turkish and other Unicode characters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1fff9aa1c832b9b0b3d6a7963bdc6